### PR TITLE
Gradient compatible wati

### DIFF
--- a/mitwindfarm/Rotor.py
+++ b/mitwindfarm/Rotor.py
@@ -111,7 +111,9 @@ class AD(Rotor):
         xs_glob, ys_glob, zs_glob = xs_loc + x, ys_loc + y, zs_loc + z
 
         # sample windfield and calculate rotor effective wind speed
-        Us, TIs = windfield.wsp_and_TI(xs_glob, ys_glob, zs_glob)
+        Us = windfield.wsp(xs_glob, ys_glob, zs_glob)
+        TIs = windfield.TI(xs_glob, ys_glob, zs_glob)
+        
         REWS = self.rotor_grid.average(Us)
         RETI = np.sqrt(self.rotor_grid.average(TIs**2))
 
@@ -172,7 +174,9 @@ class UnifiedAD(Rotor):
         xs_glob, ys_glob, zs_glob = xs_loc + x, ys_loc + y, zs_loc + z
 
         # sample windfield and calculate rotor effective wind speed
-        Us, TIs = windfield.wsp_and_TI(xs_glob, ys_glob, zs_glob)
+        Us = windfield.wsp(xs_glob, ys_glob, zs_glob)
+        TIs = windfield.TI(xs_glob, ys_glob, zs_glob)
+
         REWS = self.rotor_grid.average(Us)
         RETI = np.sqrt(self.rotor_grid.average(TIs**2))
 
@@ -235,7 +239,9 @@ class BEM(Rotor):
         xs_glob = self.xgrid_loc + x
         ys_glob = self.ygrid_loc + y
         zs_glob = self.zgrid_loc + z
-        Us, TIs = windfield.wsp_and_TI(xs_glob, ys_glob, zs_glob)
+        Us = windfield.wsp(xs_glob, ys_glob, zs_glob)
+        TIs = windfield.TI(xs_glob, ys_glob, zs_glob)
+
         REWS = self._model.geometry.rotor_average(self._model.geometry.annulus_average(Us))
         RETI = np.sqrt(self._model.geometry.rotor_average(self._model.geometry.annulus_average(TIs**2)))
 

--- a/mitwindfarm/Wake.py
+++ b/mitwindfarm/Wake.py
@@ -3,7 +3,7 @@ from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import ArrayLike
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from scipy.special import erf
 
 if TYPE_CHECKING:
@@ -71,7 +71,7 @@ class GaussianWake(Wake):
         d = self._wake_diameter(_x)
 
         dv = -0.5 / d**2 * (1 + erf(_x / (np.sqrt(2) / 2)))
-        _yc = cumtrapz(-dv, dx=dx, initial=0)
+        _yc = cumulative_trapezoid(-dv, dx=dx, initial=0)
 
         return _x, _yc
 

--- a/mitwindfarm/Windfield.py
+++ b/mitwindfarm/Windfield.py
@@ -255,15 +255,15 @@ class Superimposed(Windfield):
 
     def wsp_and_TI(self, x: ArrayLike, y: ArrayLike, z: ArrayLike) -> ArrayLike:
         wsp_base, TI_base = self.base_windfield.wsp_and_TI(x, y, z)
-        deficits, WATIs = [], []
+        deficits = []
+        max_WATI = np.zeros_like(wsp_base)
         for wake in self.wakes:
             _deficit, _WATI = wake.deficit_and_WATI(x, y, z)
             deficits.append(_deficit)
-            WATIs.append(_WATI)
+            max_WATI = np.maximum(_WATI, max_WATI)
 
         if len(deficits) == 0:
             deficits.append(np.zeros_like(wsp_base))
-            WATIs.append(np.zeros_like(wsp_base))
 
         if self.method == "linear":
             wsp_out = wsp_base - np.sum(deficits, axis=0)
@@ -273,7 +273,7 @@ class Superimposed(Windfield):
             wsp_out = wsp_base - deficits.max(axis=0, initial=0)
         else:
             raise NotImplementedError
-        TI_out = np.sqrt(TI_base**2 + np.max(WATIs, axis=0) ** 2)
+        TI_out = np.sqrt(TI_base**2 + max_WATI**2)
 
         return wsp_out, TI_out
 

--- a/mitwindfarm/__init__.py
+++ b/mitwindfarm/__init__.py
@@ -2,6 +2,6 @@ from ._Layout import GridLayout, Square, Layout
 from .Rotor import RotorSolution, AD, UnifiedAD, BEM
 from .RotorGrid import Point, Line, Area
 from .Superposition import Linear, Quadratic, Dominant
-from .Wake import WakeModel, GaussianWakeModel, GaussianWake
+from .Wake import WakeModel, GaussianWakeModel, GaussianWake, VariableKwGaussianWakeModel
 from .windfarm import WindfarmSolution, PartialWindfarmSolution, Windfarm
 from .Windfield import Uniform, PowerLaw, Superimposed

--- a/tests/test_windfield.py
+++ b/tests/test_windfield.py
@@ -36,9 +36,6 @@ def test_custom_windfield():
         def TI(self, x, y, z):
             return x - y - z
 
-        def wsp_and_TI(self, x, y, z):
-            return x - y * z
-
     custom_windfield = CustomWindfield()
     x = np.array([1, 2, 3])
     y = np.array([4, 5, 6])


### PR DESCRIPTION
Updated wake-added TI method.

### Features
- Gradient-compatible with Dualitic
- Simplify models by removing joint wsp and TI methods as there was no clear benefit.
- Add sigma multiplier to WATI gaussian width (default is 1.0).
- Add `VariableKwGaussianWakeModel` which takes a linear fit of WATI and CTprime to determine the wake spreading rate (`kw`) for each wake.
- Fix tests relating to depreciation of `scipy.integrate.cumtrapz`