### PR TITLE
Add a windfarm object which uses an analytically averaged wind speed and turbulence intensity.

### DIFF
--- a/checks/check_lineavg.py
+++ b/checks/check_lineavg.py
@@ -1,0 +1,49 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from mitwindfarm import Windfarm, AnalyticalWindfarm, Windfarm, Line, AD, Layout
+
+windfarm_lineavg = AnalyticalWindfarm(TIamb= 0.07)
+windfarm_lineavg.wake_model.WATI_sigma_multiplier = 2.0
+windfarm_sample = Windfarm(rotor_model=AD(rotor_grid=Line()), TIamb= 0.07)
+windfarm_sample.wake_model.WATI_sigma_multiplier = 2.0
+
+def get_rews_sample(y):
+    layout = Layout([0.0, 10.0], [0.0, y])
+    setpoints = [(2.0, 0.0), (2.0, 0.0)]
+    sol = windfarm_sample(layout=layout, setpoints=setpoints)
+    return sol.rotors[1].REWS
+
+def get_rews_lineavg(y):
+    layout = Layout([0.0, 10.0], [0.0, y])
+    setpoints = [(2.0, 0.0), (2.0, 0.0)]
+    sol = windfarm_lineavg(layout=layout, setpoints=setpoints)
+    return sol.rotors[1].REWS
+
+def get_RETI_sample(y):
+    layout = Layout([0.0, 10.0], [0.0, y])
+    setpoints = [(2.0, 0.0), (2.0, 0.0)]
+    sol = windfarm_sample(layout=layout, setpoints=setpoints)
+    return sol.rotors[1].TI
+
+def get_RETI_lineavg(y):
+    layout = Layout([0.0, 10.0], [0.0, y])
+    setpoints = [(2.0, 0.0), (2.0, 0.0)]
+    sol = windfarm_lineavg(layout=layout, setpoints=setpoints)
+    return sol.rotors[1].TI
+
+ys = np.linspace(-5, 5, 150)
+line_rews = [get_rews_lineavg(y) for y in ys]
+sample_rews = [get_rews_sample(y) for y in ys]
+
+# plt.plot(ys, line_rews, label = "line")
+# plt.plot(ys, sample_rews, label = "sample")
+# plt.legend()
+# plt.show()
+
+line_ti = [get_RETI_lineavg(y) for y in ys]
+sample_ti = [get_RETI_sample(y) for y in ys]
+
+plt.plot(ys, line_ti, label = "line")
+plt.plot(ys, sample_ti, label = "sample")
+plt.legend()
+plt.show()

--- a/mitwindfarm/__init__.py
+++ b/mitwindfarm/__init__.py
@@ -1,7 +1,7 @@
 from ._Layout import GridLayout, Square, Layout
-from .Rotor import RotorSolution, AD, UnifiedAD, BEM
+from .Rotor import RotorSolution, AD, UnifiedAD, BEM, AnalyticalAD, AnalyticalUnifiedAD
 from .RotorGrid import Point, Line, Area
 from .Superposition import Linear, Quadratic, Dominant
 from .Wake import WakeModel, GaussianWakeModel, GaussianWake, VariableKwGaussianWakeModel
-from .windfarm import WindfarmSolution, PartialWindfarmSolution, Windfarm
+from .windfarm import WindfarmSolution, PartialWindfarmSolution, Windfarm, AnalyticalWindfarm
 from .Windfield import Uniform, PowerLaw, Superimposed

--- a/mitwindfarm/windfarm.py
+++ b/mitwindfarm/windfarm.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, asdict
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 from ._Layout import Layout
-from .Rotor import Rotor, AD, RotorSolution
+from .Rotor import Rotor, AD, AnalyticalAD, AnalyticalUnifiedAD, RotorSolution
 from .Windfield import Windfield, Uniform
-from .Wake import WakeModel, Wake, GaussianWakeModel
+from .Wake import WakeModel, Wake, GaussianWakeModel, VariableKwGaussianWakeModel
 from .Superposition import Superposition, Linear
 
 
@@ -99,3 +99,18 @@ class Windfarm:
 
     def from_dict(self, partial: dict) -> WindfarmSolution:
         return self.from_partial(PartialWindfarmSolution.from_dict(partial))
+
+
+class AnalyticalWindfarm(Windfarm):
+    def __init__(
+        self,
+        rotor_model: Union[AnalyticalAD, AnalyticalUnifiedAD] = None,
+        wake_model: Union[GaussianWakeModel, VariableKwGaussianWakeModel] = None,
+        base_windfield: Optional[Windfield] = None,
+        TIamb: float = None
+    ):
+        self.rotor_model = AnalyticalAD() if rotor_model is None else rotor_model
+        self.wake_model = GaussianWakeModel() if wake_model is None else wake_model
+        self.superposition = Linear()
+        self.base_windfield = Uniform(TIamb=TIamb) if base_windfield is None else base_windfield
+        self.TIamb = TIamb

--- a/tests/test_windfield.py
+++ b/tests/test_windfield.py
@@ -35,6 +35,12 @@ def test_custom_windfield():
 
         def TI(self, x, y, z):
             return x - y - z
+        
+        def line_wsp(self, x, y, z):
+            return x - y - z
+        
+        def line_TI(self, x, y, z):
+            return x * y * z
 
     custom_windfield = CustomWindfield()
     x = np.array([1, 2, 3])


### PR DESCRIPTION
This merge includes the following additions:

a wind farm object (`AnalyticalWindfarm`) which:
- uses an analytical line average of the wake deficit and wake added TI gaussian distributions.
- has restricted set of rotor, wake and superposition models.
- uses dedicated rotor models: `AnalyticalAD` or `AnalyticalUnifiedAD`.
- is a  subclass of `Windfarm`

two rotor objects (`AnalyticalAD` or `AnalyticalUnifiedAD`) which:
- solve for REWS calling a special windfield attribute: `line_wsp`
- solve for RETI by calling a special windfield attribute: `line_TI`

 a windfield attribute (`line_wsp`) which:
- returns the line averaged wind speed by calling `line_deficit`

a windfield attribute (`line_TI`) which:
- returns the line averaged turbulence intensity by calling `line_wake_added_turbulence`

a wake attribute (`line_wake_added_turbulence`)
- returns the line averaged wake added turbulence of a turbine
